### PR TITLE
Add more fleshed-out render logic

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,18 +1,19 @@
 class Cell
 
-  attr_reader :coordinate
+  attr_reader :coordinate, :occupied
   attr_accessor :ship
 
   def initialize(coordinate)
     @coordinate = coordinate
     @ship = nil
     @fired_counter = 0
+    @occupied = occupied
     # @render = {"nothing" => ".",
     #             "hit" => "H",
     #             "miss" => "M",
     #             "sunk" => "X",
     #             "ship" => "S"}
-end
+  end
 
   def empty?
     if ship == nil
@@ -29,7 +30,6 @@ end
   def fired_upon?
     if @fired_counter == 0
       false
-      # @render.key("nothing")
     else
       true
     end
@@ -42,12 +42,25 @@ end
     @fired_counter += 1
   end
 
-  def render
+  def render(show_ship = false)
+
     if @fired_counter == 0
-      "."
-    elsif @fired_counter > 0
-      "M"
+      if show_ship = true && @ship != nil
+        "S"
+      else
+        "."
+      end
+    else #fire_counter > 0
+      if @ship == nil
+        "M"
+      elsif @ship != nil
+        if @ship.sunk? == false
+          "H"
+        else
+          "X"
+        end
+      end
     end
   end
 
-end
+  end

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -3,6 +3,9 @@ require './lib/ship'
 require './lib/cell'
 
 RSpec.describe Cell do
+before(:each) do
+
+end
 
   it 'is an instance of cell' do
     cell = Cell.new("B4")
@@ -37,11 +40,24 @@ RSpec.describe Cell do
     expect(cell.fired_upon?).to be(true)
   end
 
-  it 'renders' do
+  it 'renders for no ship in the cell' do
     cell_1 = Cell.new("B4")
-    # require 'pry'; binding.pry
     expect(cell_1.render).to eq(".")
     cell_1.fire_upon
     expect(cell_1.render).to eq("M")
+  end
+
+  it 'renders when cell is occupied' do
+    cell_2 = Cell.new("C3")
+    cruiser = Ship.new("Cruiser", 3)
+    cell_2.place_ship(cruiser)
+    expect(cell_2.render(true)).to eq("S")
+    cell_2.fire_upon
+    expect(cell_2.render).to eq("H")
+    expect(cruiser.sunk?).to be(false)
+    cruiser.hit
+    cruiser.hit
+    expect(cruiser.sunk?).to be(true)
+    expect(cell_2.render).to eq("X")
   end
 end


### PR DESCRIPTION
I re-structured the render logic so that it first looks at whether the @fired_counter is zero, and shows a dot or "S" based on the boolean passed in (per the interaction pattern). Then the logic considers whether a ship object exists in the cell object, and returns the correct values depending whether the ship is sunk. 

We can talk this through first thing at our pairing sesh tomorrow!