### PR TITLE
Feat: logic to prevent overlap and place ships into cell objects

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,3 +1,6 @@
+require_relative "cell"
+require_relative "ship"
+
 class Board
 
   attr_reader :cells
@@ -67,12 +70,21 @@ class Board
 
   def valid_placement?(ship, coordinates)
     if coordinates.all? {|coord| valid_coordinate?(coord)} && ship.length == coordinates.length
-      if coordinates_with_same_letter?(ship, coordinates) && consecutive_coordinate_nums?(ship, coordinates)
-        return true
-      elsif consecutive_coordinate_letters?(ship, coordinates) && coordinates_with_same_nums?(ship, coordinates)
-        return true
+      if coordinates.all? {|coord| @cells[coord].empty?}
+        if coordinates_with_same_letter?(ship, coordinates) && consecutive_coordinate_nums?(ship, coordinates)
+          return true
+        elsif consecutive_coordinate_letters?(ship, coordinates) && coordinates_with_same_nums?(ship, coordinates)
+          return true
+        end
       end
     end
     return false
   end
+
+  def place(ship, coordinates)
+    coordinates.each do |coord|
+      @cells[coord].place_ship(ship)
+    end
+  end
+
 end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,3 +1,5 @@
+require_relative 'ship'
+
 class Cell
 
   attr_reader :coordinate, :occupied

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Board do
   it "valid placement? ship length" do
     expect(@board.valid_placement?(@cruiser, ["A1", "A2"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["A2", "A3", "A4"])).to eq(false)
+    expect(@board.valid_placement?(@cruiser, ["A2", "A3", "A4"])).to eq(true)
   end
 
   it "valid placement? consecutive coordinates" do
@@ -61,7 +62,7 @@ RSpec.describe Board do
     expect(@board.valid_placement?(@submarine, ["A3", "A2", "A1"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["C1", "B1"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["A1", "A1"])).to eq(false)
-
+    expect(@board.valid_placement?(@submarine, ["A1", "A2"])).to eq(true)
   end
 
   it "valid placement? valid coordinates" do
@@ -77,6 +78,19 @@ RSpec.describe Board do
   it "valid placement? good examples" do
     expect(@board.valid_placement?(@submarine, ["A1", "A2"])).to eq(true)
     expect(@board.valid_placement?(@cruiser, ["B1", "C1", "D1"])).to eq(true)
+  end
+
+  it "place ships" do
+    @board.place(@cruiser, ["A1", "A2", "A3"])
+    cell_1 = @board.cells["A1"]
+    cell_2 = @board.cells["A2"]
+    cell_3 = @board.cells["A3"]
+    expect(cell_3.ship == cell_2.ship).to eq(true)
+  end
+
+  it "prevent overlap" do
+    @board.place(@cruiser, ["A1", "A2", "A3"])
+    expect(@board.valid_placement?(@submarine, ["A1", "B1"])).to be(false)
   end
 
 end


### PR DESCRIPTION
This adds one more level to our "if" logic in valid_placement?: if each coordinate in the argument is empty (via the @cells hash values), continue with the if statement. We also paired to add the place method, which adds the same ship object to each coordinate in our @cells hash.