### PR TITLE
Feat/Bug: Add create_custom_ships and fix turn-spec

### DIFF
--- a/lib/play.rb
+++ b/lib/play.rb
@@ -9,7 +9,7 @@ attr_accessor :computer_board, :player_board, :computer_ships, :player_ships
     @computer_board = nil
     @player_board = nil
     @computer_ships = nil
-    @player_ships = nil
+    @player_ships = []
   end
 
   def start
@@ -30,8 +30,12 @@ attr_accessor :computer_board, :player_board, :computer_ships, :player_ships
       if user_response == "p"
 
         @computer_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
-        @player_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
+        # @player_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
+
         self.set_up_game
+        self.create_custom_ships
+        self.random_computer_placements
+        self.player_placements
         self.play_process
       elsif user_response == "q"
         puts "Goodbye!"
@@ -51,8 +55,36 @@ attr_accessor :computer_board, :player_board, :computer_ships, :player_ships
     @computer_board.custom_board_setup
     #create player_board cells the same size as computer board
     @player_board.custom_board_setup
-    self.random_computer_placements
-    self.player_placements
+  end
+
+  def create_custom_ships
+    puts "Time to create your ships!"
+    puts "Remember your ship length maximum is #{@columns}."
+
+      loop do
+        puts "Please name your ship:"
+        name = gets.chomp
+        puts "How long is #{name}?"
+        
+          loop do
+            length = gets.chomp.to_i
+            if length > @columns
+              puts "Invalid length, please try again:"
+            elsif length <= @columns
+              ship = Ship.new(name, length)
+              @player_ships << ship
+              break
+            end
+          end
+
+        puts "Would you like to create another ship?"
+        puts "Enter y for Yes or n for No:"
+        print ">"
+        user_response = gets.chomp
+        if user_response == "n"
+          break
+        end
+      end
   end
 
   def random_computer_placements
@@ -66,9 +98,8 @@ attr_accessor :computer_board, :player_board, :computer_ships, :player_ships
   end
 
   def player_placements
-    puts "I have laid out my ships on the grid."
-    puts "You now need to lay out your own two ships."
-    puts "The Cruiser is three cells long, and the Submarine is two cells long."
+    puts "I have laid out my ships on the grid. I have two ships: The Cruiser is three cells long, and the Submarine is two cells long."
+    puts "You now need to lay out your own #{@player_ships.length} ships."
 
     @player_ships.each do |item|
       loop do

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Board do
     @board = Board.new
     @cruiser = Ship.new("Cruiser", 3)
     @submarine = Ship.new("Submarine", 2)
+    @carrier = Ship.new("Carrier", 4)
     @board.custom_board_setup
   end
 
@@ -56,6 +57,7 @@ RSpec.describe Board do
     expect(@board.valid_placement?(@cruiser, ["A1", "A2"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["A2", "A3", "A4"])).to eq(false)
     expect(@board.valid_placement?(@cruiser, ["A2", "A3", "A4"])).to eq(true)
+    expect(@board.valid_placement?(@carrier, ["A1", "A2", "A3", "A4"])).to eq(true)
   end
 
   it "valid placement? consecutive coordinates" do
@@ -65,11 +67,13 @@ RSpec.describe Board do
     expect(@board.valid_placement?(@submarine, ["C1", "B1"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["A1", "A1"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["A1", "A2"])).to eq(true)
+    expect(@board.valid_placement?(@carrier, ["A1", "A2", "A3", "A4"])).to eq(true)
   end
 
   it "valid placement? valid coordinates" do
     expect(@board.valid_placement?(@cruiser, ["A1", "B2", "BORK"])).to eq(false)
     expect(@board.valid_placement?(@submarine, ["C2", "D33"])).to eq(false)
+    expect(@board.valid_placement?(@carrier, ["A1", "B1", "C1", "D1"])).to eq(true)
   end
 
   it "valid placement? diagonals" do

--- a/spec/play_spec.rb
+++ b/spec/play_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Play do
     @computer_board = Board.new
     @player_board = Board.new
     @computer_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
-    @player_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
+    @player_ships = [Ship.new("U.S.S. Sierra", 4), Ship.new("U.S.S. Hannah", 5)]
   end
 
   it 'exists' do

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Turn do
     @play.player_board = Board.new
     @play.computer_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
     @play.player_ships = [Ship.new("Cruiser", 3), Ship.new("Submarine", 2)]
+    @play.computer_board.custom_board_setup
+    @play.player_board.custom_board_setup
     @turn.computer_turn
     @possible_shots = @play.player_board.cells.values.select {|cell| cell.fired_upon? == false}
     @computer_shot = @possible_shots.sample


### PR DESCRIPTION
Final paired work to add custom ships feature and add in the missing custom board method in our turn_spec testing. All tests pass and runner file functioning as desired. 